### PR TITLE
Increase PHP memory limit to 1GB (wordpress container)

### DIFF
--- a/configs/php.ini-development
+++ b/configs/php.ini-development
@@ -398,7 +398,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 1024M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -1714,7 +1714,7 @@ zend.assertions = 1
 ;mbstring.http_output_conv_mimetype=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
-; to the pcre.recursion_limit for PCRE. 
+; to the pcre.recursion_limit for PCRE.
 ; Default: 100000
 ;mbstring.regex_stack_limit=100000
 


### PR DESCRIPTION
Fix issue where master builds would fail due to fatal PHP error "out of memory"